### PR TITLE
Split Message types into separate classes

### DIFF
--- a/src/main/java/net/dv8tion/discord/bridge/IrcConnection.java
+++ b/src/main/java/net/dv8tion/discord/bridge/IrcConnection.java
@@ -19,6 +19,8 @@ import net.dv8tion.discord.bridge.endpoint.EndPoint;
 import net.dv8tion.discord.bridge.endpoint.EndPointInfo;
 import net.dv8tion.discord.bridge.endpoint.EndPointManager;
 import net.dv8tion.discord.bridge.endpoint.EndPointMessage;
+import net.dv8tion.discord.bridge.endpoint.messages.DiscordEndPointMessage;
+import net.dv8tion.discord.bridge.endpoint.messages.IrcEndPointMessage;
 import net.dv8tion.jda.events.Event;
 import net.dv8tion.jda.events.message.guild.GenericGuildMessageEvent;
 import net.dv8tion.jda.events.message.guild.GuildMessageDeleteEvent;
@@ -105,7 +107,7 @@ public class IrcConnection extends ListenerAdapter<PircBotX> implements EventLis
         EndPoint endPoint = BridgeManager.getInstance().getOtherEndPoint(EndPointInfo.createFromIrcChannel(identifier, event.getChannel()));
         if (endPoint != null)
         {
-            EndPointMessage message = EndPointMessage.createFromIrcEvent(event);
+            EndPointMessage message = new IrcEndPointMessage(event);
             endPoint.sendMessage(message);
         }
     }
@@ -146,7 +148,7 @@ public class IrcConnection extends ListenerAdapter<PircBotX> implements EventLis
         EndPoint endPoint = BridgeManager.getInstance().getOtherEndPoint(EndPointInfo.createFromDiscordChannel(e.getChannel()));
         if (endPoint != null)
         {
-            EndPointMessage message = EndPointMessage.createFromDiscordEvent(e);
+            EndPointMessage message = new DiscordEndPointMessage(e);
             endPoint.sendMessage(message);
         }
     }

--- a/src/main/java/net/dv8tion/discord/bridge/endpoint/EndPointMessage.java
+++ b/src/main/java/net/dv8tion/discord/bridge/endpoint/EndPointMessage.java
@@ -15,63 +15,16 @@
  */
 package net.dv8tion.discord.bridge.endpoint;
 
-import net.dv8tion.jda.entities.Message;
-import net.dv8tion.jda.entities.User;
-import net.dv8tion.jda.events.message.guild.GenericGuildMessageEvent;
-import org.pircbotx.PircBotX;
-import org.pircbotx.hooks.events.MessageEvent;
-
 public class EndPointMessage
 {
-    private EndPointType messageType;
+    //private EndPointType messageType;
     private String senderName;
     private String message;
 
-    // -- Discord specific --
-    private GenericGuildMessageEvent discordEvent;
-    private User discordUser;
-    private Message discordMessage;
-
-    // -- irc specific --
-    private MessageEvent<? extends PircBotX> ircEvent;
-    private org.pircbotx.User ircUser;
-
-    private EndPointMessage() {}
-
-    public static EndPointMessage create(String senderName, String message)
+    public EndPointMessage(String senderName, String message)
     {
-        return create(EndPointType.UNKNOWN, senderName, message);
-    }
-
-    public static EndPointMessage create(EndPointType messageType, String senderName, String msg)
-    {
-        EndPointMessage message = new EndPointMessage();
-        message.messageType = messageType;
-        message.senderName = senderName;
-        message.message = msg;
-        return message;
-    }
-
-    public static EndPointMessage createFromDiscordEvent(GenericGuildMessageEvent event)
-    {
-        EndPointMessage message = new EndPointMessage();
-        message.messageType = EndPointType.DISCORD;
-        message.setDiscordMessage(event.getMessage());
-        message.senderName = event.getAuthor().getUsername();
-        message.discordEvent = event;
-        message.discordUser = event.getAuthor();
-        return message;
-    }
-
-    public static EndPointMessage createFromIrcEvent(MessageEvent<? extends PircBotX> event)
-    {
-        EndPointMessage message = new EndPointMessage();
-        message.message = event.getMessage();
-        message.messageType = EndPointType.IRC;
-        message.senderName = event.getUser().getNick();
-        message.ircEvent = event;
-        message.ircUser = event.getUser();
-        return message;
+        this.senderName = senderName;
+        this.message = message;
     }
 
     public String getSenderName()
@@ -87,61 +40,5 @@ public class EndPointMessage
     public void setMessage(String message)
     {
         this.message = message;
-    }
-
-    public EndPointType getType()
-    {
-        return messageType;
-    }
-
-    // ------ Discord Specific ------
-
-    public User getDiscordUser()
-    {
-        if (!messageType.equals(EndPointType.DISCORD))
-            throw new IllegalStateException("Attempted to get Discord user from a non-Discord message");
-        return discordUser;
-    }
-
-    public GenericGuildMessageEvent getDiscordEvent()
-    {
-        if (!messageType.equals(EndPointType.DISCORD))
-            throw new IllegalStateException("Attemped to get Discord event for non-Discord message");
-         return discordEvent;
-    }
-
-    public Message getDiscordMessage()
-    {
-        if (!messageType.equals(EndPointType.DISCORD))
-            throw new IllegalStateException("Attempted to get Discord message from a non-Discord message");
-        return discordMessage;
-    }
-
-    public void setDiscordMessage(Message discordMessage)
-    {
-        String parsedMessage = discordMessage.getContent();
-        for (Message.Attachment attach : discordMessage.getAttachments())
-        {
-            parsedMessage += "\n" + attach.getUrl();
-        }
-
-        this.message = parsedMessage;
-        this.discordMessage = discordMessage;
-    }
-
-    // ------ IRC Specific ------
-
-    public MessageEvent<? extends PircBotX> getIrcEvent()
-    {
-        if (!messageType.equals(EndPointType.IRC))
-            throw new IllegalStateException("Attemped to get IRC event for non-IRC message");
-        return ircEvent;
-    }
-
-    public org.pircbotx.User getIrcUser()
-    {
-        if (!messageType.equals(EndPointType.IRC))
-            throw new IllegalStateException("Attemped to get IRC user for non-IRC message");
-        return ircUser;
     }
 }

--- a/src/main/java/net/dv8tion/discord/bridge/endpoint/messages/DiscordEndPointMessage.java
+++ b/src/main/java/net/dv8tion/discord/bridge/endpoint/messages/DiscordEndPointMessage.java
@@ -1,0 +1,48 @@
+package net.dv8tion.discord.bridge.endpoint.messages;
+
+import net.dv8tion.discord.bridge.endpoint.EndPointMessage;
+import net.dv8tion.jda.entities.Message;
+import net.dv8tion.jda.entities.User;
+import net.dv8tion.jda.events.message.guild.GenericGuildMessageEvent;
+
+public class DiscordEndPointMessage extends EndPointMessage
+{
+    private GenericGuildMessageEvent discordEvent;
+    private User discordUser;
+    private Message discordMessage;
+
+    public DiscordEndPointMessage(GenericGuildMessageEvent event)
+    {
+        super(event.getAuthor().getUsername(), null);
+        this.setDiscordMessage(event.getMessage());
+        this.discordEvent = event;
+        this.discordUser = event.getAuthor();
+    }
+
+    public User getDiscordUser()
+    {
+        return discordUser;
+    }
+
+    public GenericGuildMessageEvent getDiscordEvent()
+    {
+         return discordEvent;
+    }
+
+    public Message getDiscordMessage()
+    {
+        return discordMessage;
+    }
+
+    public void setDiscordMessage(Message discordMessage)
+    {
+        String parsedMessage = discordMessage.getContent();
+        for (Message.Attachment attach : discordMessage.getAttachments())
+        {
+            parsedMessage += "\n" + attach.getUrl();
+        }
+
+        this.setMessage(parsedMessage);
+        this.discordMessage = discordMessage;
+    }
+}

--- a/src/main/java/net/dv8tion/discord/bridge/endpoint/messages/IrcEndPointMessage.java
+++ b/src/main/java/net/dv8tion/discord/bridge/endpoint/messages/IrcEndPointMessage.java
@@ -1,0 +1,29 @@
+package net.dv8tion.discord.bridge.endpoint.messages;
+
+import org.pircbotx.PircBotX;
+import org.pircbotx.hooks.events.MessageEvent;
+
+import net.dv8tion.discord.bridge.endpoint.EndPointMessage;
+
+public class IrcEndPointMessage extends EndPointMessage
+{
+    private MessageEvent<? extends PircBotX> ircEvent;
+    private org.pircbotx.User ircUser;
+
+    public IrcEndPointMessage(MessageEvent<? extends PircBotX> event)
+    {
+        super(event.getUser().getNick(), event.getMessage());
+        this.ircEvent = event;
+        this.ircUser = event.getUser();
+    }
+
+    public MessageEvent<? extends PircBotX> getIrcEvent()
+    {
+        return ircEvent;
+    }
+
+    public org.pircbotx.User getIrcUser()
+    {
+        return ircUser;
+    }
+}

--- a/src/main/java/net/dv8tion/discord/bridge/endpoint/types/DiscordEndPoint.java
+++ b/src/main/java/net/dv8tion/discord/bridge/endpoint/types/DiscordEndPoint.java
@@ -20,6 +20,8 @@ import net.dv8tion.discord.bridge.endpoint.EndPoint;
 import net.dv8tion.discord.bridge.endpoint.EndPointInfo;
 import net.dv8tion.discord.bridge.endpoint.EndPointMessage;
 import net.dv8tion.discord.bridge.endpoint.EndPointType;
+import net.dv8tion.discord.bridge.endpoint.messages.DiscordEndPointMessage;
+import net.dv8tion.discord.bridge.endpoint.messages.IrcEndPointMessage;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.TextChannel;
 
@@ -82,14 +84,14 @@ public class DiscordEndPoint extends EndPoint
     {
         if (!connected)
             throw new IllegalStateException("Cannot send message to disconnected EndPoint! EndPoint: " + this.toEndPointInfo().toString());
-        switch (message.getType())
+        if (message instanceof DiscordEndPointMessage)
         {
-            case DISCORD:
-                getChannel().sendMessage(message.getDiscordMessage());
-                break;
-            default:
-                for (String segment : this.divideMessageForSending(message.getMessage()))
-                    sendMessage(String.format("<%s> %s", message.getSenderName(), segment));
+            getChannel().sendMessage(((DiscordEndPointMessage) message).getDiscordMessage());
+        }
+        else if (message instanceof IrcEndPointMessage)
+        {
+            for (String segment : this.divideMessageForSending(message.getMessage()))
+                sendMessage(String.format("<%s> %s", message.getSenderName(), segment));
         }
     }
 }


### PR DESCRIPTION
The old system is rather bad ...
So split messages up into separate classes to allow for easy extending.
